### PR TITLE
Linkを、ChakraNextLinkを使うように差し替えた

### DIFF
--- a/src/components/ChakraNextLink.tsx
+++ b/src/components/ChakraNextLink.tsx
@@ -1,0 +1,12 @@
+import Link, { LinkProps } from 'next/link'
+import { Link as ChakraLink, LinkProps as ChakraLinkProps } from '@chakra-ui/react'
+
+type ChakraLinkAndNextProps = ChakraLinkProps & LinkProps
+
+export default function ChakraNextLink({ href, children, ...props }: ChakraLinkAndNextProps) {
+  return (
+    <Link href={href} passHref>
+      <ChakraLink {...props}>{children}</ChakraLink>
+    </Link>
+  )
+}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -4,7 +4,6 @@ import {
   Flex,
   HStack,
   Image,
-  Link,
   IconButton,
   Button,
   Menu,
@@ -16,6 +15,7 @@ import {
   useColorModeValue,
   Stack,
 } from '@chakra-ui/react'
+import Link from './ChakraNextLink'
 import { HamburgerIcon, CloseIcon, AddIcon } from '@chakra-ui/icons'
 
 import logo from '../assets/images/logo.png'


### PR DESCRIPTION
next jsの仕様で、linkのあるところはnext/linkのLinkを使わなくてはいけないので、Chakra-uiのlinkと併用出来るようにした