### PR TITLE
Postscreenボタン調整(+その他)

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -60,7 +60,7 @@ export default function Header(props: Props) {
           />
           <HStack spacing={8} alignItems={'center'}>
             <Link href={'/'}>
-              <Box mr={props?.isPostEdit ? 16 : -8}>
+              <Box mr={-8}>
                 <Image src={logo.src} alt='nanikiru' w={120} />
               </Box>
             </Link>

--- a/src/pages/postedit/index.tsx
+++ b/src/pages/postedit/index.tsx
@@ -60,13 +60,17 @@ export default function PostEdit() {
                   choiceIndex={index}
                   removeChoice={removeChoice}
                 />
-                <Button onClick={addChoice} type={'button'}>
-                  選択肢を追加
-                </Button>
               </Box>
             )
           })}
-          <Button type='submit'>投稿</Button>
+          <Box display='flex' justifyContent='center'>
+            <Button onClick={addChoice} type={'button'} mx={2} my={2}>
+              選択肢を追加
+            </Button>
+            <Button type='submit' mx={2} my={2}>
+              投稿
+            </Button>
+          </Box>
         </FormControl>
       </form>
     </Stack>
@@ -84,9 +88,11 @@ const ChoiceItem = ({ register, choiceIndex, removeChoice }: Props) => {
     <Box>
       <FormLabel>選択肢{choiceIndex + 1}</FormLabel>
       <Input {...register(`choices.${choiceIndex}.name` as const)}></Input>
-      <Button type={'button'} onClick={() => removeChoice(choiceIndex)}>
-        削除
-      </Button>
+      <Box display='flex' justifyContent='end' mx={4}>
+        <Button type={'button'} onClick={() => removeChoice(choiceIndex)}>
+          選択肢を削除
+        </Button>
+      </Box>
     </Box>
   )
 }


### PR DESCRIPTION
+一先ずボタンの位置調整
+スマホからの投稿ページ移動用の投稿ボタンを変更するため、一旦ヘッダーロゴのmarginを元に戻した